### PR TITLE
Fix RangeError: source array is too long exception (Cloudflare Turnstile)

### DIFF
--- a/v3/data/inject/main.js
+++ b/v3/data/inject/main.js
@@ -11,7 +11,14 @@
     const {width, height} = canvas;
     const context = canvas.getContext('2d', {willReadFrequently: true});
     const matt = getImageData.apply(context, [0, 0, width, height]);
-    matt.data.set(map.get(canvas));
+    const saved = map.get(canvas);
+
+    // Prevent crash on buffers missmatch, handle some rare edge case with Cloudflare Captcha (aka Cloudflare Turnstile)
+    if (!saved || saved.byteLength !== matt.data.byteLength) {
+      return;
+    }
+
+    matt.data.set(saved);
     map.delete(canvas);
 
     // canvas.getContext('2d', {willReadFrequently: true}).putImageData(matt, 0, 0);


### PR DESCRIPTION
This fix will prevent issues with CF captcha (aka Cloudflare Turnstile) and related to #18 